### PR TITLE
Fix `bdist_wheel` migrating into `setuptools`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,32 +20,31 @@ jobs:
           - '3.12'
           - '3.11'
           - '3.10'
-          - '3.9'
         pip-version:
+          - '24.2'
           - '24.1'
           - '24.0'
           - '23.3'
           - '22.3'
         setuptools-version:
-          - '70.1'
-          - '70.0'
+          - '72.1'
+          - '71.1'
+          - '70.3'
           - '69.5'
           - '68.2'
-          - '67.0'
-          - '66.0'
-          - '65.0'
+          - '67.8'
+          - '66.1'
+          - '65.7'
         exclude:
           - python-version: '3.12'
-            setuptools-version: '65.0'
-          - python-version: '3.12'
-            pip-version: '22.2'
+            setuptools-version: '65.7'
           - python-version: '3.12'
             pip-version: '22.3'
     env:
       DEPLOY_PYTHONS: "3.12"
       DEPLOY_OSES: "Linux"
-      DEPLOY_PIPS: "24.0"
-      DEPLOY_SETUPTOOLS: "70.0"
+      DEPLOY_PIPS: "24.2"
+      DEPLOY_SETUPTOOLS: "72.1"
       TWINE_USERNAME: __token__
       TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -74,6 +73,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           pyb-extra-args: ${{ env.PYB_EXTRA_ARGS }}
   build-secondary:
+    needs: 'build-primary'
     runs-on: ${{ matrix.os }}
     continue-on-error: false
     strategy:
@@ -83,39 +83,26 @@ jobs:
           - ubuntu-latest
           - macos-13
         python-version:
+          - '3.9'
           - '3.8'
-          - '3.7'
         pip-version:
+          - '24.2'
           - '24.1'
           - '24.0'
           - '23.3'
           - '22.3'
         setuptools-version:
-          - '70.1'
-          - '70.0'
+          - '72.1'
+          - '71.1'
+          - '70.3'
           - '69.5'
           - '68.2'
-          - '68.1'
-          - '68.0'
-          - '67.0'
-          - '66.0'
-          - '65.0'
+          - '67.8'
+          - '66.1'
+          - '65.7'
           - '64.0'
-          - '63.0'
-          - '62.0'
-        exclude:
-          - python-version: '3.7'
-            setuptools-version: '68.2'
-          - python-version: '3.7'
-            setuptools-version: '68.1'
-          - python-version: '3.7'
-            setuptools-version: '69.5'
-          - python-version: '3.7'
-            setuptools-version: '70.0'
-          - python-version: '3.7'
-            setuptools-version: '70.1'
-          - python-version: '3.7'
-            pip-version: '24.1'
+          - '63.4'
+          - '62.6'
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -133,6 +120,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           pyb-extra-args: ${{ env.PYB_EXTRA_ARGS }}
   build-experimental:
+    needs: 'build-primary'
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     strategy:
@@ -144,9 +132,9 @@ jobs:
         python-version:
           - '3.13-dev'
         pip-version:
-          - '24.1'
+          - '24.2'
         setuptools-version:
-          - '70.1'
+          - '72.1'
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.11 (wheel-axle-3.11.2)" />
+  </component>
   <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.11 (wheel-axle-3.11.2)" project-jdk-type="Python SDK" />
 </project>

--- a/src/integrationtest/python/build_axle_tests.py
+++ b/src/integrationtest/python/build_axle_tests.py
@@ -25,7 +25,16 @@ from os.path import dirname, join as jp, exists
 from subprocess import check_call
 from tempfile import TemporaryDirectory
 
-from wheel.bdist_wheel import get_abi_tag, get_platform, tags
+try:
+    # SetupTools >= 70.1
+    from setuptools.command.bdist_wheel import get_abi_tag, get_platform, tags
+except ImportError:
+    try:
+        # Wheel >= 0.44.0
+        from wheel._bdist_wheel import get_abi_tag, get_platform, tags
+    except ImportError:
+        # Wheel < 0.44.0
+        from wheel.bdist_wheel import get_abi_tag, get_platform, tags
 
 
 class BuildAxleTest(unittest.TestCase):

--- a/src/main/python/wheel_axle/bdist_axle/__init__.py
+++ b/src/main/python/wheel_axle/bdist_axle/__init__.py
@@ -32,7 +32,21 @@ from setuptools.command.egg_info import egg_info, manifest_maker, FileList
 from setuptools.command.install import install
 from setuptools.command.install_lib import install_lib
 from setuptools.command.install_scripts import install_scripts
-from wheel.bdist_wheel import bdist_wheel as _bdist_wheel, python_tag
+
+try:
+    # SetupTools >= 70.1
+    from setuptools.command.bdist_wheel import bdist_wheel as _bdist_wheel, python
+except ImportError:
+    try:
+        # Wheel >= 0.44.0
+        from wheel._bdist_wheel import bdist_wheel as _bdist_wheel, python_tag
+    except ImportError:
+        # Wheel < 0.44.0
+        try:
+            from wheel.bdist_wheel import bdist_wheel as _bdist_wheel, python_tag
+        except ImportError:
+            raise ImportError("Either `setuptools>=70.1` package or `wheel` package is required")
+
 from wheel.vendored.packaging import tags
 
 from wheel_axle.bdist_axle._file_utils import copy_link, copy_tree


### PR DESCRIPTION
If `setuptools>=70.1` are available - use that
Otherwise support `wheel` versions before and after migration

fixes #22